### PR TITLE
Scrum 273 check receiver antenna type for validity against the .atx file

### DIFF
--- a/app/controllers/input_controller.py
+++ b/app/controllers/input_controller.py
@@ -223,7 +223,7 @@ class InputController(QObject):
                 label = line[60:].strip()
 
                 # Read and find antenna_type tag
-                if label == "TYPE / SERIAL NO":
+                if label == "TYPE / SERIAL NO" and line[20:24].strip() == "":
                     valid_antenna_type = line[0:20]
 
                     if len(valid_antenna_type.strip()) < 16 or not valid_antenna_type[16:].strip():


### PR DESCRIPTION
Extracted antenna_type is verified by checking if it exists within the igs.atx file (i.e. "igs20.atx"). If it does, pass, if it does not, throw a warning to notify the user.

Client provided feedback - really happy with it, suggested extension feature